### PR TITLE
Check requirement exists

### DIFF
--- a/src/GoLoadUp.php
+++ b/src/GoLoadUp.php
@@ -97,7 +97,9 @@ class GoLoadUp
                 $requirement?->errorMessage()
             );
 
-            if (! is_null($requirement)) $this->validateCartRequirementQuantity($requirement, $cartItem);
+            if (! is_null($requirement)) {
+                $this->validateCartRequirementQuantity($requirement, $cartItem);
+            }
         };
     }
 

--- a/src/GoLoadUp.php
+++ b/src/GoLoadUp.php
@@ -97,7 +97,7 @@ class GoLoadUp
                 $requirement?->errorMessage()
             );
 
-            $this->validateCartRequirementQuantity($requirement, $cartItem);
+            if (! is_null($requirement)) $this->validateCartRequirementQuantity($requirement, $cartItem);
         };
     }
 


### PR DESCRIPTION
Now checking to make sure a requirement exist before attempting to validate the requirement quantity against that of the cart item. This is required to prevent this error from happening again: https://linear.app/3zbrands/issue/PAN-356/typeerror-astrogoat/goloadup/goloadupvalidatecartrequirementquantity

